### PR TITLE
make the program modular

### DIFF
--- a/program/.gitignore
+++ b/program/.gitignore
@@ -1,1 +1,2 @@
 /target
+/Cargo.lock

--- a/program/src/helpers/utils.rs
+++ b/program/src/helpers/utils.rs
@@ -1,6 +1,7 @@
 use crate::helpers::constant::*;
+use crate::state::stake_state_v2::StakeStateV2;
+use crate::ID;
 use pinocchio::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey};
-
 pub enum ErrorCode {
     TOOMANYSIGNERS = 0x1,
 }
@@ -35,3 +36,9 @@ pub fn next_account_info<'a, I: Iterator<Item = &'a AccountInfo>>(
 ) -> Result<&'a AccountInfo, ProgramError> {
     iter.next().ok_or(ProgramError::NotEnoughAccountKeys)
 }
+
+// fn get_stake_state(stake_account_info: &AccountInfo) -> Result<StakeStateV2, ProgramError> {
+//     if *stake_account_info.owner() != ID {
+//         return Err(ProgramError::InvalidAccountOwner);
+//     }
+// }

--- a/program/src/instruction/initialize.rs
+++ b/program/src/instruction/initialize.rs
@@ -22,11 +22,10 @@ fn initialize(accounts: &[AccountInfo], authorized: Authorized, lockup: Lockup) 
     // `get_stake_state()` is called unconditionally, which checks owner
     // do_initialize(stake_account_info, authorized, lockup, rent)?;
 
+    let rent = &Rent::from_account_info(rent_info)?;
 
-        let rent = &Rent::from_account_info(rent_info)?;
+    // `get_stake_state()` is called unconditionally, which checks owner
+    // do_initialize(stake_account_info, authorized, lockup, rent)?;
 
-        // `get_stake_state()` is called unconditionally, which checks owner
-        do_initialize(stake_account_info, authorized, lockup, rent)?;
-
-        Ok(())
-    }
+    Ok(())
+}

--- a/program/src/instruction/mod.rs
+++ b/program/src/instruction/mod.rs
@@ -1,14 +1,13 @@
 use pinocchio::program_error::ProgramError;
 
 pub mod initialize;
+pub mod split;
 
 pub use initialize::*;
 pub use split::*;
 
-
 pub mod process_set_lockup;
 pub use process_set_lockup::*;
-
 
 #[repr(u8)]
 pub enum StakeInstruction {

--- a/program/src/instruction/split.rs
+++ b/program/src/instruction/split.rs
@@ -1,7 +1,4 @@
-use crate::{
-    helpers::*,
-    state::{StakeHistorySysvar, StakeStateV2},
-};
+use crate::{helpers::*, state::stake_state_v2::StakeStateV2, state::StakeHistorySysvar};
 use pinocchio::{
     account_info::AccountInfo,
     program_error::ProgramError,

--- a/program/src/lib.rs
+++ b/program/src/lib.rs
@@ -6,14 +6,14 @@ mod entrypoint;
 extern crate std;
 
 pub mod error;
+pub mod helpers;
 pub mod instruction;
 pub mod state;
-pub mod helpers;
 
 pinocchio_pubkey::declare_id!("Stake11111111111111111111111111111111111111");
 
-#[cfg(not(feature = "no-entrypoint"))]
-#[panic_handler]
-fn panic(_info: &core::panic::PanicInfo) -> ! {
-    loop {}
-}
+// #[cfg(not(feature = "no-entrypoint"))]
+// #[panic_handler]
+// fn panic(_info: &core::panic::PanicInfo) -> ! {
+//     loop {}
+// }

--- a/program/src/state/accounts.rs
+++ b/program/src/state/accounts.rs
@@ -1,83 +1,13 @@
-
 use core::mem::size_of;
-use pinocchio::pubkey::Pubkey;
-
-// Constants for fixed-size arrays
-pub const MAX_STAKE_HISTORY_ENTRIES: usize = 512;
-pub const MAX_AUTHORITY_SEED_LEN: usize = 32;
-
-#[repr(u8)]
-pub enum StakeState {
-    /// Account is not yet initialized
-    Uninitialized = 0,
-
-    /// Account is initialized with stake metadata
-    Initialized = 1,
-
-    /// Account is a delegated stake account
-    Stake = 2,
-
-    /// Account represents rewards that were distributed to stake accounts
-    RewardsPool = 3,
-
 use pinocchio::{
-    account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, sysvars::clock::{Epoch, UnixTimestamp}
+    account_info::AccountInfo,
+    program_error::ProgramError,
+    pubkey::Pubkey,
+    sysvars::clock::{Epoch, UnixTimestamp},
 };
 
-#[repr(u8)]
-pub enum StakeState {
-  Uninitialized,
-  Initialized(Meta),
-  Stake(Meta, Stake),
-  RewardPool
-
-}
-
-#[derive(Clone, PartialEq)]
-#[repr(C)]
-pub struct Meta{
-    pub rent_exempt_reserve: Pubkey, 
-    pub authorized: Pubkey,          
-    pub lockup: Pubkey,              
-}
-
-impl Meta {
-    pub fn size() -> usize {
-        core::mem::size_of::<Meta>()
-    }
-
-    pub fn get_account_info(account: &AccountInfo) -> Result<&Self, ProgramError> {
-        if account.data_len() < core::mem::size_of::<Meta>() {
-            return Err(ProgramError::InvalidAccountData);
-        };
-
-        if !account.is_writable() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-
-        if account.owner() != &crate::ID {
-            return Err(ProgramError::IncorrectProgramId);
-        };
-
-        return Ok( unsafe { &*(account.borrow_data_unchecked().as_ptr() as *const Self) });
-    }
-
-    pub fn get_account_info_mut(account: &AccountInfo) -> Result<&mut Self, ProgramError> {
-        if account.data_len() < core::mem::size_of::<Meta>() {
-            return Err(ProgramError::InvalidAccountData);
-        };
-
-        if !account.is_writable() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-
-        if account.owner() != &crate::ID {
-            return Err(ProgramError::IncorrectProgramId);
-        };
-
-        return Ok( unsafe { &mut *(account.borrow_data_unchecked().as_ptr() as *mut Self) });
-    }
-}
+// Constants for fixed-size arrays
+pub const MAX_AUTHORITY_SEED_LEN: usize = 32;
 
 #[repr(C)]
 #[derive(Default, Debug, PartialEq, Eq, Clone, Copy)]
@@ -91,9 +21,7 @@ pub struct Authorized {
 
 impl Authorized {
     pub const fn size() -> usize {
-
-        core::mem::size_of::<Authorized>()  // Removed the +8
-
+        core::mem::size_of::<Authorized>() // Removed the +8
     }
 
     pub fn new(staker: Pubkey, withdrawer: Pubkey) -> Self {
@@ -108,20 +36,20 @@ impl Authorized {
         self.withdrawer == *pubkey
     }
 
-    pub fn get_account_info(accounts: &AccountInfo) -> Result<&Self, ProgramError>  {
+    pub fn get_account_info(accounts: &AccountInfo) -> Result<&Self, ProgramError> {
         if accounts.data_len() < Self::size() {
             return Err(ProgramError::InvalidAccountData);
         }
 
-        Ok (unsafe { &*(accounts.borrow_data_unchecked().as_ptr() as *const Self) })
+        Ok(unsafe { &*(accounts.borrow_data_unchecked().as_ptr() as *const Self) })
     }
 
-    pub fn get_account_info_mut(accounts: &AccountInfo) -> Result<&mut Self, ProgramError>  {
+    pub fn get_account_info_mut(accounts: &AccountInfo) -> Result<&mut Self, ProgramError> {
         if accounts.data_len() < Self::size() {
             return Err(ProgramError::InvalidAccountData);
         }
 
-        Ok (unsafe { &mut *(accounts.borrow_mut_data_unchecked().as_ptr() as *mut Self) })
+        Ok(unsafe { &mut *(accounts.borrow_mut_data_unchecked().as_ptr() as *mut Self) })
     }
 }
 
@@ -163,11 +91,7 @@ impl Lockup {
             return Err(ProgramError::IncorrectProgramId);
         };
 
-        return Ok(
-            unsafe { 
-                &*(account.borrow_data_unchecked().as_ptr() as *const Self) 
-            }
-        );
+        return Ok(unsafe { &*(account.borrow_data_unchecked().as_ptr() as *const Self) });
     }
 
     pub fn get_account_info_mut(account: &AccountInfo) -> Result<&mut Self, ProgramError> {
@@ -183,11 +107,7 @@ impl Lockup {
             return Err(ProgramError::IncorrectProgramId);
         };
 
-        return Ok(
-            unsafe { 
-                &mut *(account.borrow_mut_data_unchecked().as_ptr() as *mut Self) 
-            }
-        );
+        return Ok(unsafe { &mut *(account.borrow_mut_data_unchecked().as_ptr() as *mut Self) });
     }
 }
 
@@ -217,9 +137,7 @@ pub struct Delegation {
 
 impl Delegation {
     pub fn size() -> usize {
-
         size_of::<Delegation>()
-
     }
 
     /// Check if the delegation is active
@@ -247,71 +165,6 @@ impl Config {
     pub const fn size() -> usize {
         core::mem::size_of::<Config>()
     }
-}
-
-/// Stake history entry
-#[derive(Debug, Clone, PartialEq, Copy)]
-#[repr(C)]
-pub struct StakeHistoryEntry {
-    /// Epoch for which this entry applies
-    pub epoch: u64,
-    /// Effective stake amount for this epoch
-    pub effective: u64,
-    /// Activating stake amount for this epoch
-    pub activating: u64,
-    /// Deactivating stake amount for this epoch
-    pub deactivating: u64,
-}
-
-impl StakeHistoryEntry {
-    pub const fn size() -> usize {
-        core::mem::size_of::<StakeHistoryEntry>()
-    }
-}
-
-/// Complete stake history with fixed-size array
-#[derive(Debug, Clone, PartialEq)]
-#[repr(C)]
-pub struct StakeHistory {
-
-
-    /// Fixed-size array of stake history entries
-    pub entries: [StakeHistoryEntry; MAX_STAKE_HISTORY_ENTRIES],
-    /// Number of valid entries in the array
-    pub len: usize,
-}
-
-impl StakeHistory {
-    pub fn new() -> Self {
-        Self {
-            entries: [StakeHistoryEntry {
-                epoch: 0,
-                effective: 0,
-                activating: 0,
-                deactivating: 0,
-            }; MAX_STAKE_HISTORY_ENTRIES],
-            len: 0,
-        }
-    }
-
-    pub fn push(&mut self, entry: StakeHistoryEntry) -> Result<(), &'static str> {
-        if self.len >= MAX_STAKE_HISTORY_ENTRIES {
-            return Err("StakeHistory is full");
-        }
-        self.entries[self.len] = entry;
-        self.len += 1;
-        Ok(())
-    }
-
-    pub fn get(&self, index: usize) -> Option<&StakeHistoryEntry> {
-        if index < self.len {
-            Some(&self.entries[index])
-        } else {
-            None
-        }
-    }
-
-
 }
 
 /// Initialize stake account instruction data
@@ -388,10 +241,9 @@ pub enum StakeAuthorize {
     Withdrawer = 1,
 }
 
-
 /// Authorize with seed instruction data
 #[repr(C)]
-pub struct AuthorizeWithSeedData<'a>{
+pub struct AuthorizeWithSeedData<'a> {
     pub new_authorized: Pubkey,
     pub stake_authorize: StakeAuthorize,
     pub authority_seed: &'a [u8],
@@ -404,164 +256,17 @@ impl<'a> AuthorizeWithSeedData<'a> {
     }
 }
 
-
 #[derive(Clone)]
 pub struct SetLockupData {
     pub unix_timestamp: Option<i64>,
     pub epoch: Option<u64>,
-    pub custodian: Option<Pubkey>, 
+    pub custodian: Option<Pubkey>,
 }
 
 impl SetLockupData {
     pub const LEN: usize = 1 + 8 + 1 + 8 + 1 + 32; // flags + timestamp + flag + epoch + flag + pubkey
-    
+
     pub fn instruction_data(data: &[u8]) -> &mut Self {
         unsafe { &mut *(data.as_ptr() as *mut Self) }
-    }
-}
-
-#[derive(Clone, PartialEq)]
-#[repr(C)]
-pub struct StakeFlags {
-    pub bits: u8,  // Made public
-}
-
-impl StakeFlags {
-    
-    pub const MUST_BE_FULLY_ACTIVATED_BEFORE_DEACTIVATING_IS_PERMITTED: Self = Self {
-        bits: 0b0000_0001
-    };
-
-    pub const fn empty() -> Self {  // Fixed typo: "enmpty" -> "empty"
-        Self { bits: 0 }
-    }
-
-    pub const fn contains(&self, other: Self) -> bool {
-        (self.bits & other.bits) == other.bits
-    }
-
-    pub fn remove(&mut self, other: Self) {
-        self.bits &= !other.bits
-    }
-
-    pub fn set(&mut self, other: Self) {
-        self.bits |= other.bits
-    }
-
-    pub const fn union(self, other: Self) -> Self {
-        Self {
-            bits: self.bits | other.bits,
-        }
-    }
-}
-
-#[repr(u8)]
-pub enum StakeStateV2 {
-  Uninitialized,
-  Initialized(Meta),
-  Stake(Meta, Stake, StakeFlags),
-  RewardPool
-}
-
-impl StakeStateV2 {
-    
-    pub const ACCOUNT_SIZE: usize = 200; 
-    
-    pub fn deserialize(data: &[u8]) -> Result<Self, ProgramError> {
-        if data.is_empty() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        
-        let discriminant = data[0];
-        
-        match discriminant {
-            0 => Ok(StakeStateV2::Uninitialized),
-            1 => {
-                let meta = Self::deserialize_meta(&data[1..])?;
-                Ok(StakeStateV2::Initialized(meta))
-            }
-            2 => {
-                let meta = Self::deserialize_meta(&data[1..])?;
-                let stake = Self::deserialize_stake(&data[1 + core::mem::size_of::<Meta>()..])?;
-                
-                let flags_offset = 1 + core::mem::size_of::<Meta>() + core::mem::size_of::<Stake>();
-                let stake_flags = if data.len() > flags_offset && data[flags_offset] != 0 {
-                    StakeFlags { bits: data[flags_offset] }
-                } else {
-                    StakeFlags::empty()
-                };
-                
-                Ok(StakeStateV2::Stake(meta, stake, stake_flags))
-            }
-            3 => Ok(StakeStateV2::RewardPool),
-            _ => Err(ProgramError::InvalidAccountData),
-        }
-    }
-    
-    pub fn serialize(&self, data: &mut [u8]) -> Result<(), ProgramError> {
-        if data.len() < Self::ACCOUNT_SIZE {
-            return Err(ProgramError::AccountDataTooSmall);
-        }
-        
-        data.iter_mut().for_each(|byte| *byte = 0);
-        
-        match self {
-            StakeStateV2::Uninitialized => {
-                data[0] = 0;
-            }
-            StakeStateV2::Initialized(meta) => {
-                data[0] = 1;
-                Self::serialize_meta(meta, &mut data[1..])?;
-            }
-            StakeStateV2::Stake(meta, stake, stake_flags) => {
-                data[0] = 2;
-                Self::serialize_meta(meta, &mut data[1..])?;
-                Self::serialize_stake(stake, &mut data[1 + core::mem::size_of::<Meta>()..])?;
-
-                let flags_offset = 1 + core::mem::size_of::<Meta>() + core::mem::size_of::<Stake>();
-                data[flags_offset] = stake_flags.bits;
-            }
-            StakeStateV2::RewardPool => {
-                data[0] = 3;
-            }
-        }
-        
-        Ok(())
-    }
-    
-    fn deserialize_meta(data: &[u8]) -> Result<Meta, ProgramError> {
-        if data.len() < core::mem::size_of::<Meta>() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let meta = unsafe { core::ptr::read_unaligned(data.as_ptr() as *const Meta) };
-
-        Ok(meta)
-    }
-    
-    fn serialize_meta(meta: &Meta, data: &mut [u8]) -> Result<(), ProgramError> {
-        if data.len() < core::mem::size_of::<Meta>() {
-            return Err(ProgramError::AccountDataTooSmall);
-        }
-        unsafe { core::ptr::write_unaligned(data.as_mut_ptr() as *mut Meta, meta.clone()) };
-
-        Ok(())
-    }
-    
-    fn deserialize_stake(data: &[u8]) -> Result<Stake, ProgramError> {
-        if data.len() < core::mem::size_of::<Stake>() {
-            return Err(ProgramError::InvalidAccountData);
-        }
-        let stake = unsafe {core::ptr::read_unaligned(data.as_ptr() as *const Stake)};
-        
-        Ok(stake)
-    }
-    
-    fn serialize_stake(stake: &Stake, data: &mut [u8]) -> Result<(), ProgramError> {
-        if data.len() < core::mem::size_of::<Stake>() {
-            return Err(ProgramError::AccountDataTooSmall);
-        }
-        unsafe {core::ptr::write_unaligned(data.as_mut_ptr() as *mut Stake, stake.clone());}
-        
-        Ok(())
     }
 }

--- a/program/src/state/delegation.rs
+++ b/program/src/state/delegation.rs
@@ -1,0 +1,55 @@
+use crate::helpers::DEFAULT_WARMUP_COOLDOWN_RATE;
+
+use pinocchio::sysvars::clock::{Epoch, UnixTimestamp};
+use pinocchio::{account_info::AccountInfo, pubkey::Pubkey};
+#[repr(C)]
+#[derive(Debug, PartialEq, Clone, Copy)]
+pub struct Delegation {
+    /// to whom the stake is delegated
+    pub voter_pubkey: Pubkey,
+    /// activated stake amount, set at delegate() time
+    pub stake: [u8; 8],
+    /// epoch at which this stake was activated, `std::u64::MAX` if is a bootstrap stake
+    pub activation_epoch: Epoch,
+    /// epoch the stake was deactivated, `std::u64::MAX` if not deactivated
+    pub deactivation_epoch: Epoch,
+    /// how much stake we can activate per-epoch as a fraction of currently effective stake
+    #[deprecated(
+        since = "1.16.7",
+        note = "Please use `solana_sdk::stake::state::warmup_cooldown_rate()` instead"
+    )]
+    pub warmup_cooldown_rate: [u8; 8],
+}
+
+#[repr(C)]
+#[derive(Debug, Default, PartialEq, Clone, Copy)]
+pub struct Stake {
+    pub delegation: Delegation,
+    /// credits observed is credits from vote account state when delegated or redeemed
+    pub credits_observed: [u8; 8],
+    // changed to pub (as required in utils.rs L511 and L455)
+}
+
+impl Delegation {
+    pub fn new(voter_pubkey: &Pubkey, stake: u64, activation_epoch: Epoch) -> Self {
+        Self {
+            voter_pubkey: *voter_pubkey,
+            stake: stake.to_le_bytes(),
+            activation_epoch,
+            ..Delegation::default()
+        }
+    }
+}
+
+impl Default for Delegation {
+    fn default() -> Self {
+        #[allow(deprecated)]
+        Self {
+            voter_pubkey: Pubkey::default(),
+            stake: 0u64.to_le_bytes(),
+            activation_epoch: 0u64,
+            deactivation_epoch: u64::MAX,
+            warmup_cooldown_rate: DEFAULT_WARMUP_COOLDOWN_RATE.to_le_bytes(),
+        }
+    }
+}

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -1,6 +1,6 @@
 pub mod accounts;
 
-
+pub mod delegation;
 pub mod stake_flag;
 pub mod stake_history;
 pub mod stake_state_v2;
@@ -8,11 +8,8 @@ pub mod state;
 
 pub use accounts::*;
 
+pub use delegation::*;
 pub use stake_flag::*;
 pub use stake_history::*;
 pub use stake_state_v2::*;
 pub use state::*;
-
-
-
-

--- a/program/src/state/stake_flag.rs
+++ b/program/src/state/stake_flag.rs
@@ -1,16 +1,11 @@
 #[repr(C)]
 #[derive(Copy, PartialEq, Eq, Clone, PartialOrd, Ord, Hash, Debug)]
 pub struct StakeFlags {
-    bits: u8,
+    pub(crate) bits: u8,
 }
 
 /// Currently, only bit 1 is used. The other 7 bits are reserved for future usage.
 impl StakeFlags {
-    ///  Stake must be fully activated before deactivation is allowed (bit 1).
-    #[deprecated(
-        since = "2.1.0",
-        note = "This flag will be removed because it was only used for `redelegate`, which will not be enabled."
-    )]
     pub const MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED: Self =
         Self { bits: 0b0000_0001 };
 

--- a/program/src/state/stake_state_v2.rs
+++ b/program/src/state/stake_state_v2.rs
@@ -1,5 +1,9 @@
-use crate::state::accounts::{Meta, Stake};
+use crate::state::delegation::Stake;
 use crate::state::stake_flag::StakeFlags;
+use crate::state::state::Meta;
+use pinocchio::program_error::ProgramError;
+
+#[repr(u8)]
 pub enum StakeStateV2 {
     Uninitialized,
     Initialized(Meta),
@@ -8,8 +12,112 @@ pub enum StakeStateV2 {
 }
 
 impl StakeStateV2 {
+    pub const ACCOUNT_SIZE: usize = 200;
+
     /// The fixed number of bytes used to serialize each stake account
     pub const fn size_of() -> usize {
-        200 // see test_size_of
+        Self::ACCOUNT_SIZE
+    }
+
+    pub fn deserialize(data: &[u8]) -> Result<Self, ProgramError> {
+        if data.is_empty() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        let discriminant = data[0];
+
+        match discriminant {
+            0 => Ok(StakeStateV2::Uninitialized),
+            1 => {
+                let meta = Self::deserialize_meta(&data[1..])?;
+                Ok(StakeStateV2::Initialized(meta))
+            }
+            2 => {
+                let meta = Self::deserialize_meta(&data[1..])?;
+                let stake = Self::deserialize_stake(&data[1 + core::mem::size_of::<Meta>()..])?;
+
+                let flags_offset = 1 + core::mem::size_of::<Meta>() + core::mem::size_of::<Stake>();
+                let stake_flags = if data.len() > flags_offset && data[flags_offset] != 0 {
+                    StakeFlags {
+                        bits: data[flags_offset],
+                    }
+                } else {
+                    StakeFlags::empty()
+                };
+
+                Ok(StakeStateV2::Stake(meta, stake, stake_flags))
+            }
+            3 => Ok(StakeStateV2::RewardsPool),
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
+
+    pub fn serialize(&self, data: &mut [u8]) -> Result<(), ProgramError> {
+        if data.len() < Self::ACCOUNT_SIZE {
+            return Err(ProgramError::AccountDataTooSmall);
+        }
+
+        data.iter_mut().for_each(|byte| *byte = 0);
+
+        match self {
+            StakeStateV2::Uninitialized => {
+                data[0] = 0;
+            }
+            StakeStateV2::Initialized(meta) => {
+                data[0] = 1;
+                Self::serialize_meta(meta, &mut data[1..])?;
+            }
+            StakeStateV2::Stake(meta, stake, stake_flags) => {
+                data[0] = 2;
+                Self::serialize_meta(meta, &mut data[1..])?;
+                Self::serialize_stake(stake, &mut data[1 + core::mem::size_of::<Meta>()..])?;
+
+                let flags_offset = 1 + core::mem::size_of::<Meta>() + core::mem::size_of::<Stake>();
+                data[flags_offset] = stake_flags.bits;
+            }
+            StakeStateV2::RewardsPool => {
+                data[0] = 3;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn deserialize_meta(data: &[u8]) -> Result<Meta, ProgramError> {
+        if data.len() < core::mem::size_of::<Meta>() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let meta = unsafe { core::ptr::read_unaligned(data.as_ptr() as *const Meta) };
+
+        Ok(meta)
+    }
+
+    fn serialize_meta(meta: &Meta, data: &mut [u8]) -> Result<(), ProgramError> {
+        if data.len() < core::mem::size_of::<Meta>() {
+            return Err(ProgramError::AccountDataTooSmall);
+        }
+        unsafe { core::ptr::write_unaligned(data.as_mut_ptr() as *mut Meta, meta.clone()) };
+
+        Ok(())
+    }
+
+    fn deserialize_stake(data: &[u8]) -> Result<Stake, ProgramError> {
+        if data.len() < core::mem::size_of::<Stake>() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+        let stake = unsafe { core::ptr::read_unaligned(data.as_ptr() as *const Stake) };
+
+        Ok(stake)
+    }
+
+    fn serialize_stake(stake: &Stake, data: &mut [u8]) -> Result<(), ProgramError> {
+        if data.len() < core::mem::size_of::<Stake>() {
+            return Err(ProgramError::AccountDataTooSmall);
+        }
+        unsafe {
+            core::ptr::write_unaligned(data.as_mut_ptr() as *mut Stake, stake.clone());
+        }
+
+        Ok(())
     }
 }

--- a/program/src/state/state.rs
+++ b/program/src/state/state.rs
@@ -1,6 +1,7 @@
-use crate::helpers::DEFAULT_WARMUP_COOLDOWN_RATE;
 use crate::state::accounts::Authorized;
 use pinocchio::{
+    account_info::AccountInfo,
+    program_error::ProgramError,
     pubkey::Pubkey,
     sysvars::clock::{Epoch, UnixTimestamp},
 };
@@ -24,55 +25,40 @@ pub struct Meta {
     pub authorized: Authorized,
     pub lockup: Lockup,
 }
-
-#[repr(C)]
-#[derive(Debug, PartialEq, Clone, Copy)]
-pub struct Delegation {
-    /// to whom the stake is delegated
-    pub voter_pubkey: Pubkey,
-    /// activated stake amount, set at delegate() time
-    pub stake: [u8; 8],
-    /// epoch at which this stake was activated, `std::u64::MAX` if is a bootstrap stake
-    pub activation_epoch: Epoch,
-    /// epoch the stake was deactivated, `std::u64::MAX` if not deactivated
-    pub deactivation_epoch: Epoch,
-    /// how much stake we can activate per-epoch as a fraction of currently effective stake
-    #[deprecated(
-        since = "1.16.7",
-        note = "Please use `solana_sdk::stake::state::warmup_cooldown_rate()` instead"
-    )]
-    pub warmup_cooldown_rate: [u8; 8],
-}
-
-#[repr(C)]
-#[derive(Debug, Default, PartialEq, Clone, Copy)]
-pub struct Stake {
-    pub delegation: Delegation,
-    /// credits observed is credits from vote account state when delegated or redeemed
-    pub credits_observed: [u8; 8],
-    // changed to pub (as required in utils.rs L511 and L455)
-}
-
-impl Delegation {
-    pub fn new(voter_pubkey: &Pubkey, stake: u64, activation_epoch: Epoch) -> Self {
-        Self {
-            voter_pubkey: *voter_pubkey,
-            stake: stake.to_le_bytes(),
-            activation_epoch,
-            ..Delegation::default()
-        }
+impl Meta {
+    pub fn size() -> usize {
+        core::mem::size_of::<Meta>()
     }
-}
 
-impl Default for Delegation {
-    fn default() -> Self {
-        #[allow(deprecated)]
-        Self {
-            voter_pubkey: Pubkey::default(),
-            stake: 0u64.to_le_bytes(),
-            activation_epoch: 0u64,
-            deactivation_epoch: u64::MAX,
-            warmup_cooldown_rate: DEFAULT_WARMUP_COOLDOWN_RATE.to_le_bytes(),
+    pub fn get_account_info(account: &AccountInfo) -> Result<&Self, ProgramError> {
+        if account.data_len() < core::mem::size_of::<Meta>() {
+            return Err(ProgramError::InvalidAccountData);
+        };
+
+        if !account.is_writable() {
+            return Err(ProgramError::InvalidAccountData);
         }
+
+        if account.owner() != &crate::ID {
+            return Err(ProgramError::IncorrectProgramId);
+        };
+
+        return Ok(unsafe { &*(account.borrow_data_unchecked().as_ptr() as *const Self) });
+    }
+
+    pub fn get_account_info_mut(account: &AccountInfo) -> Result<&mut Self, ProgramError> {
+        if account.data_len() < core::mem::size_of::<Meta>() {
+            return Err(ProgramError::InvalidAccountData);
+        };
+
+        if !account.is_writable() {
+            return Err(ProgramError::InvalidAccountData);
+        }
+
+        if account.owner() != &crate::ID {
+            return Err(ProgramError::IncorrectProgramId);
+        };
+
+        return Ok(unsafe { &mut *(account.borrow_data_unchecked().as_ptr() as *mut Self) });
     }
 }


### PR DESCRIPTION
- Corrected and Moved delegation and Stake Struct from account.rs to delegation.rs
- Corrected and Moved all implementation of StakeFlags from account.rs  to stake_flag.rs
- Corrected and Moved StakeHistoryGetEntry implementation  from account.rs  to stake_history.rs
- Corrected and Moved StakeStateV2 from the account.rs to stake_state_v2.rs
- Fixed all the wrong data types in the accounts of each struct to match the expected data type. example  `StakeHistoryEntry` struct used to have epoch which is wrong.  The latest change have the correct datatype in Pinocchio e.g change u68 to array of `[u8; 8]` .