### PR TITLE
feat:  Add move_stake and redelegate instructions

### DIFF
--- a/program/src/helpers/merge.rs
+++ b/program/src/helpers/merge.rs
@@ -1,0 +1,95 @@
+use pinocchio::{account_info::AccountInfo, program_error::ProgramError, sysvars::clock::Clock};
+
+use crate::{helpers::{checked_add, get_stake_state}, state::{delegation::Stake, MergeKind, StakeHistory}};
+
+pub fn stake_weighted_credits_observed(
+    stake: &Stake,
+    absorbed_lamports: u64,
+    absorbed_credits_observed: u64,
+) -> Option<u64> {
+    if stake.credits_observed == absorbed_credits_observed {
+        Some(stake.credits_observed)
+    } else {
+        let total_stake = u128::from(stake.delegation.stake.checked_add(absorbed_lamports)?);
+        let stake_weighted_credits =
+            u128::from(stake.credits_observed).checked_mul(u128::from(stake.delegation.stake))?;
+        let absorbed_weighted_credits =
+            u128::from(absorbed_credits_observed).checked_mul(u128::from(absorbed_lamports))?;
+        // Discard fractional credits as a merge side-effect friction by taking
+        // the ceiling, done by adding `denominator - 1` to the numerator.
+        let total_weighted_credits = stake_weighted_credits
+            .checked_add(absorbed_weighted_credits)?
+            .checked_add(total_stake)?
+            .checked_sub(1)?;
+        u64::try_from(total_weighted_credits.checked_div(total_stake)?).ok()
+    }
+}
+
+pub fn merge_delegation_stake_and_credits_observed(
+    stake: &mut Stake,
+    lamports_to_merge: u64,
+    source_credits_observed: u64,
+) -> Result<(), ProgramError> {
+    stake.delegation.stake = checked_add(stake.delegation.stake, lamports_to_merge)?;
+
+   stake.credits_observed =
+       stake_weighted_credits_observed(stake, lamports_to_merge, source_credits_observed)
+           .ok_or(ProgramError::ArithmeticOverflow)?;
+
+    Ok(())
+}
+
+pub fn move_stake_or_lamports_shared_checks(
+    source_stake_account_info: &AccountInfo,
+    lamports: u64,
+    destination_stake_account_info: &AccountInfo,
+    stake_authority_info: &AccountInfo,
+) -> Result<(MergeKind, MergeKind), ProgramError> {
+    
+    // Authority must sign (simplified check)
+    if !stake_authority_info.is_signer() {
+        return Err(ProgramError::MissingRequiredSignature);
+    }
+
+    // Confirm not the same account
+    if *source_stake_account_info.key() == *destination_stake_account_info.key() {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    // Source and destination must be writable
+    if !source_stake_account_info.is_writable() || !destination_stake_account_info.is_writable() {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+
+    // Must move something
+    if lamports == 0 {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    let clock = Clock::get()?;
+    let stake_history = StakeHistory::new();
+
+    // Get if mergeable ensures accounts are not partly activated or in any form of deactivating
+    let source_merge_kind = MergeKind::get_if_mergeable(
+        &get_stake_state(source_stake_account_info)?,
+        source_stake_account_info.lamports(),
+        &clock,
+        &stake_history,
+    )?;
+
+    let destination_merge_kind = MergeKind::get_if_mergeable(
+        &get_stake_state(destination_stake_account_info)?,
+        destination_stake_account_info.lamports(),
+        &clock,
+        &stake_history,
+    )?;
+
+    // Ensure all authorities match and lockups match if lockup is in force
+    MergeKind::metas_can_merge(
+        source_merge_kind.meta(),
+        destination_merge_kind.meta(),
+        &clock,
+    )?;
+
+    Ok((source_merge_kind, destination_merge_kind))
+}

--- a/program/src/helpers/mod.rs
+++ b/program/src/helpers/mod.rs
@@ -1,5 +1,8 @@
 pub mod constant;
 pub mod utils;
+pub mod merge;
 
 pub use constant::*;
 pub use utils::*;
+pub use merge::*;
+

--- a/program/src/helpers/utils.rs
+++ b/program/src/helpers/utils.rs
@@ -128,3 +128,7 @@ pub fn redelegate_stake(
     stake.set_credits_observed(vote_state.credits());
     Ok(())
 }
+
+pub(crate) fn checked_add(a: u64, b: u64) -> Result<u64, ProgramError> {
+    a.checked_add(b).ok_or(ProgramError::InsufficientFunds)
+}

--- a/program/src/instruction/mod.rs
+++ b/program/src/instruction/mod.rs
@@ -15,6 +15,12 @@ pub use process_authorized_with_seeds::*;
 pub mod process_delegate;
 pub use process_delegate::*;
 
+pub mod process_move_stake;
+pub use process_move_stake::*;
+
+pub mod process_redelegate;
+pub use process_redelegate::*;
+
 #[repr(u8)]
 pub enum StakeInstruction {
     Initialize,

--- a/program/src/instruction/process_move_stake.rs
+++ b/program/src/instruction/process_move_stake.rs
@@ -1,0 +1,162 @@
+use pinocchio::{
+    account_info::AccountInfo, 
+    program_error::ProgramError,
+    ProgramResult,
+};
+
+use crate::helpers::{merge_delegation_stake_and_credits_observed, move_stake_or_lamports_shared_checks, set_stake_state};
+use crate::error::StakeError;
+use crate::state::{MergeKind, StakeFlags, StakeStateV2};
+
+pub fn relocate_lamports(
+    source_account_info: &AccountInfo,
+    destination_account_info: &AccountInfo,
+    lamports: u64,
+) -> Result<(), ProgramError> {
+    {
+        let mut source_lamports = source_account_info.try_borrow_mut_lamports()?;
+        *source_lamports = source_lamports
+            .checked_sub(lamports)
+            .ok_or(ProgramError::InsufficientFunds)?;
+    }
+    {
+        let mut destination_lamports = destination_account_info.try_borrow_mut_lamports()?;
+        *destination_lamports = destination_lamports
+            .checked_add(lamports)
+            .ok_or(ProgramError::ArithmeticOverflow)?;
+    }
+    Ok(())
+}
+
+pub fn move_stake(
+    accounts: &[AccountInfo],
+    lamports: u64,
+) -> ProgramResult {
+    if accounts.len() < 3 {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    }
+
+    let source_stake_account_info = &accounts[0];
+    let destination_stake_account_info = &accounts[1];
+    let stake_authority_info = &accounts[2];
+
+    let (source_merge_kind, destination_merge_kind) = move_stake_or_lamports_shared_checks(
+        source_stake_account_info,
+        lamports,
+        destination_stake_account_info,
+        stake_authority_info,
+    )?;
+
+    // Ensure source and destination are the right size for the current version of
+    // StakeState - safeguard in case there is a new version of the struct
+    if source_stake_account_info.data_len() != StakeStateV2::size_of()
+        || destination_stake_account_info.data_len() != StakeStateV2::size_of()
+    {
+        return Err(ProgramError::InvalidAccountData);
+    }
+
+    // Source must be fully active
+    let MergeKind::FullyActive(source_meta, mut source_stake) = source_merge_kind else {
+        return Err(ProgramError::InvalidAccountData);
+    };
+
+    let minimum_delegation = get_minimum_delegation();
+    let source_effective_stake = source_stake.delegation.stake;
+
+    // Source cannot move more stake than it has, regardless of how many lamports it has
+    let source_final_stake = source_effective_stake
+        .checked_sub(lamports)
+        .ok_or(ProgramError::InvalidArgument)?;
+
+    // unless all stake is being moved, source must retain at least the minimum delegation
+    if source_final_stake != 0 && source_final_stake < minimum_delegation {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    // destination must be fully active or fully inactive
+    let destination_meta = match destination_merge_kind {
+        MergeKind::FullyActive(destination_meta, mut destination_stake) => {
+            // If active, destination must be delegated to the same vote account as source
+            if source_stake.delegation.voter_pubkey != destination_stake.delegation.voter_pubkey {
+                return Err(StakeError::VoteAddressMismatch.into());
+            }
+
+            let destination_effective_stake = destination_stake.delegation.stake;
+            let destination_final_stake = destination_effective_stake
+                .checked_add(lamports)
+                .ok_or(ProgramError::ArithmeticOverflow)?;
+
+            // Ensure destination meets minimum delegation
+            // Since it is already active, this only really applies if the minimum is raised
+            if destination_final_stake < minimum_delegation {
+                return Err(ProgramError::InvalidArgument);
+            }
+
+            merge_delegation_stake_and_credits_observed(
+                &mut destination_stake,
+                lamports,
+                source_stake.credits_observed,
+            )?;
+
+            // StakeFlags::empty() is valid here because the only existing stake flag,
+            // MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED, does not apply to active stakes
+            set_stake_state(
+                destination_stake_account_info,
+                &StakeStateV2::Stake(destination_meta.clone(), destination_stake, StakeFlags::empty()),
+            )?;
+
+            destination_meta
+        }
+        MergeKind::Inactive(destination_meta, _, _) => {
+            // If destination is inactive, it must be given at least the minimum delegation
+            if lamports < minimum_delegation {
+                return Err(ProgramError::InvalidArgument);
+            }
+
+            let mut destination_stake = source_stake.clone();
+            destination_stake.delegation.stake = lamports;
+
+            // StakeFlags::empty() is valid here because the only existing stake flag,
+            // MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED, is cleared when a stake is activated
+            set_stake_state(
+                destination_stake_account_info,
+                &StakeStateV2::Stake(destination_meta.clone(), destination_stake, StakeFlags::empty()),
+            )?;
+
+            destination_meta
+        }
+        _ => return Err(ProgramError::InvalidAccountData),
+    };
+
+    if source_final_stake == 0 {
+        set_stake_state(
+            source_stake_account_info,
+            &StakeStateV2::Initialized(source_meta.clone()),
+        )?;
+    } else {
+        source_stake.delegation.stake = source_final_stake;
+
+        // StakeFlags::empty() is valid here because the only existing stake flag,
+        // MUST_FULLY_ACTIVATE_BEFORE_DEACTIVATION_IS_PERMITTED, does not apply to active stakes
+        set_stake_state(
+            source_stake_account_info,
+            &StakeStateV2::Stake(source_meta.clone(), source_stake, StakeFlags::empty()),
+        )?;
+    }
+
+    relocate_lamports(
+        source_stake_account_info,
+        destination_stake_account_info,
+        lamports,
+    )?;
+
+    // This should be impossible, but because we do all our math with delegations,
+    // best to guard it
+    if source_stake_account_info.lamports() < source_meta.rent_exempt_reserve
+        || destination_stake_account_info.lamports() < destination_meta.rent_exempt_reserve
+    {
+        return Err(ProgramError::InvalidArgument);
+    }
+
+    Ok(())
+}

--- a/program/src/instruction/process_redelegate.rs
+++ b/program/src/instruction/process_redelegate.rs
@@ -1,0 +1,101 @@
+use pinocchio::{account_info::AccountInfo, program_error::ProgramError, pubkey::Pubkey, sysvars::clock::Clock, ProgramResult};
+
+use crate::{error::to_program_error, helpers::{collect_signers, get_vote_state, new_stake, redelegate_stake, set_stake_state, validate_delegated_amount, ValidatedDelegatedInfo, MAXIMUM_SIGNERS}, state::{StakeAuthorize, StakeFlags, StakeHistory, StakeStateV2}};
+
+pub fn redelegate(accounts: &[AccountInfo]) -> ProgramResult {
+    // Check for enough accounts
+    if accounts.len() < 5 {
+        return Err(ProgramError::NotEnoughAccountKeys);
+    }
+    
+    // Collect all signer pubkeys for authorization checks
+    let mut signers_array = [Pubkey::default(); MAXIMUM_SIGNERS];
+    let signers_count = collect_signers(accounts,&mut signers_array)?;
+    let signers = &signers_array[..signers_count];
+
+    // Get the required accounts
+    let stake_account_info = &accounts[0];
+    let vote_account_info = &accounts[1];
+    let clock_info = &accounts[2];
+    // We access accounts[3] and accounts[4] but don't use them directly
+    // They're provided for compatibility with the Solana stake program interface
+    
+    // Make sure accounts are valid
+    if !stake_account_info.is_writable() {
+        return Err(ProgramError::InvalidAccountData);
+    }
+    
+    // Get clock and stake history
+    let clock = Clock::from_account_info(clock_info)?;
+    let stake_history = StakeHistory::new();
+    
+    // Get vote state from the vote account
+    let vote_state = get_vote_state(vote_account_info)?;
+    
+    // Get current state of the stake account
+    let stake_state = StakeStateV2::deserialize(stake_account_info)?;
+    
+    // Process based on current stake state
+    match stake_state {
+        StakeStateV2::Initialized(meta) => {
+            // Verify authorization
+            meta.check(&signers, StakeAuthorize::Staker)
+                .map_err(to_program_error)?;
+            
+            // Validate delegation amount
+            let ValidatedDelegatedInfo { stake_amount } =
+                validate_delegated_amount(stake_account_info, &meta)?;
+            
+            // Create new stake with delegation to the vote account
+            let stake = new_stake(
+                stake_amount,
+                vote_account_info.key(),
+                &vote_state,
+                clock.epoch,
+            );
+            
+            // Update stake state with new delegation
+            set_stake_state(
+                stake_account_info,
+                &StakeStateV2::Stake(meta, stake, StakeFlags::empty()),
+            )?;
+            
+            // Successfully delegated stake
+        },
+        StakeStateV2::Stake(meta, mut stake, flags) => {
+            // Verify authorization
+            meta.check(&signers, StakeAuthorize::Staker)
+                .map_err(to_program_error)?;
+            
+            // Validate redelegation amount
+            let ValidatedDelegatedInfo { stake_amount } =
+                validate_delegated_amount(stake_account_info, &meta)?;
+            
+            // If already delegated to the same vote account, this is a no-op
+            if stake.delegation.voter_pubkey == *vote_account_info.key() {
+                return Ok(());
+            }
+            
+            // Redelegate to the new vote account
+            redelegate_stake(
+                &mut stake,
+                stake_amount,
+                vote_account_info.key(),
+                &vote_state,
+                clock.epoch,
+                &stake_history,
+            )?;
+            
+            // Update stake state with new delegation
+            set_stake_state(
+                stake_account_info,
+                &StakeStateV2::Stake(meta, stake, flags),
+            )?;
+            
+            // Successfully redelegated stake
+        },
+        _ => return Err(ProgramError::InvalidAccountData),
+    }
+    
+    Ok(())
+}

--- a/program/src/state/merge_kind.rs
+++ b/program/src/state/merge_kind.rs
@@ -1,0 +1,73 @@
+use pinocchio::{program_error::ProgramError, sysvars::clock::Clock};
+
+use crate::{error::StakeError, state::{delegation::Stake, Meta, StakeFlags, StakeHistory, StakeStateV2}};
+
+#[derive(Clone, Debug, PartialEq)]
+pub enum MergeKind {
+    Inactive(Meta, u64, StakeFlags),
+    ActivationEpoch(Meta, Stake, StakeFlags),
+    FullyActive(Meta, Stake),
+}
+
+impl MergeKind {
+    /// Get metadata from any merge kind
+    pub fn meta(&self) -> &Meta {
+        match self {
+            MergeKind::Inactive(meta, _, _) => meta,
+            MergeKind::ActivationEpoch(meta, _, _) => meta,
+            MergeKind::FullyActive(meta, _) => meta,
+        }
+    }
+
+    /// Check if stake state can be merged
+    pub fn get_if_mergeable(
+        stake_state: &StakeStateV2,
+        lamports: u64,
+        _clock: &Clock,
+        _stake_history: &StakeHistory,
+    ) -> Result<Self, ProgramError> {
+        match stake_state {
+            StakeStateV2::Stake(meta, stake, stake_flags) => {
+                // Simplified logic, later => this would check epochs
+                if stake.delegation.deactivation_epoch == u64::MAX {
+                    Ok(MergeKind::FullyActive(meta.clone(), stake.clone()))
+                } else {
+                    Ok(MergeKind::ActivationEpoch(meta.clone(), stake.clone(), stake_flags.clone()))
+                }
+            }
+            StakeStateV2::Initialized(meta) => {
+                Ok(MergeKind::Inactive(meta.clone(), lamports, StakeFlags::empty()))
+            }
+            _ => Err(ProgramError::InvalidAccountData),
+        }
+    }
+
+    /// Verify metas can be merged (authorities and lockups match)
+    pub fn metas_can_merge(
+        stake: &Meta,
+        source: &Meta,
+        clock: &Clock,
+    ) -> Result<(), ProgramError> {
+        // Check authorities match
+        if stake.authorized.staker != source.authorized.staker {
+            return Err(StakeError::MergeMismatch.into());
+        }
+
+        if stake.authorized.withdrawer != source.authorized.withdrawer {
+            return Err(StakeError::MergeMismatch.into());
+        }
+
+        // Check lockups if active
+        if stake.lockup.unix_timestamp > clock.unix_timestamp
+            || stake.lockup.epoch > clock.epoch
+        {
+            if stake.lockup.unix_timestamp != source.lockup.unix_timestamp
+                || stake.lockup.epoch != source.lockup.epoch
+            {
+                return Err(StakeError::LockupInForce.into());
+            }
+        }
+
+        Ok(())
+    }
+}

--- a/program/src/state/mod.rs
+++ b/program/src/state/mod.rs
@@ -6,6 +6,7 @@ pub mod stake_history;
 pub mod stake_state_v2;
 pub mod state;
 pub mod vote_state;
+pub mod merge_kind;
 
 pub use accounts::*;
 
@@ -15,3 +16,4 @@ pub use stake_history::*;
 pub use stake_state_v2::*;
 pub use state::*;
 pub use vote_state::*;
+pub use merge_kind::*;


### PR DESCRIPTION
### Changes:
- Added `process_move_stake.rs` with stake movement logic
- Added `process_redelegate.rs` for validator redelegation
- Created `merge.rs` helper functions for stake operations
- Added `MergeKind` enum for handling different stake states
- Updated instruction module to include new processors
